### PR TITLE
Folded tags together, fixed parsing bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ Age = 21
 ```
 
 ### MapTo special flags
-In addition to the flags mentioned above, you can specify `strictParse` and `mustExist` in a semicolon delimited list on the `iniFlags` tag in a struct definition.  `strictParse` will cause `MapTo` to return an error if a field does not parse to the type specified in the struct instead of silently failing.  `mustExist` will cause an error to be returned if the struct field does not exist in the loaded ini data.
+In addition to the flags mentioned above, you can specify `strict` and `mustExist` in a comma delimited list on the `ini` tag in a struct definition.  `strict` will cause `MapTo` to return an error if a field does not parse to the type specified in the struct instead of silently failing.  `mustExist` will cause an error to be returned if the struct field does not exist in the loaded ini data.  The first value in the `ini` tag must be the field name override as described above.  If no override is desired but other tags are needed, there must be a leading comma before the flag list.
 
 ```ini
 Name = Bob
@@ -621,26 +621,42 @@ Age = thirty
 ```go
 type Person struct {
 	Name string
-	Age int `iniFlags:"strictParse"`
+	Age int `ini:",strict"`
 }
-// Will return error from MapTo.
+// Will return error from MapTo (Field set strict, but Age cannot parse to int).
 ```
 
 ```go
 type Person struct {
 	Name string
 	Age int
-	Salary float64 `iniFlags:"mustExist"`
+	Salary float64 `ini:",mustExist"`
 }
-// Will return error from MapTo.
+// Will return error from MapTo (Salary field set mustExist, but does not exist).
 ```
 
 ```go
 type Person struct {
 	Name string
-	Age int `iniFlags:"strictParse;mustExist"`
+	Age int `ini:",strict,mustExist"`
 }
-// Will return error from MapTo.
+// Will return error from MapTo (Field set strict, but Age cannot parse to int).
+```
+
+```go
+type Person struct {
+	MyName string `ini:"Name,strict"`
+	Age int
+}
+// Will map without error.
+```
+
+```go
+type Person struct {
+	Name string `ini:"MyName,mustExist,strict"`
+	Age int
+}
+// Will return error from MapTo (No field MyName and mustExist).
 ```
 
 ## Getting Help

--- a/README.md
+++ b/README.md
@@ -519,6 +519,38 @@ Places = HangZhou,Boston
 None =
 ```
 
+What if I want to compose a struct template of other structs?
+
+### Struct pointers as field types
+
+```ini
+Foo=1
+[Bar1]
+Baz=2
+[Bar2]
+Baz=3
+```
+
+```go
+type Bar struct {
+	Baz int
+}
+
+type FullIni struct {
+	Foo int
+	Bar1 *Bar
+	Bar2 *Bar
+}
+
+func main() {
+	cfg, err := ini.Load("path/to/ini")
+	// ...
+	i := new(FullIni)
+	err = cfg.MapTo(i)
+	// ...
+}
+```
+
 #### Name Mapper
 
 To save your time and make your code cleaner, this library supports [`NameMapper`](https://gowalker.org/gopkg.in/ini.v1#NameMapper) between struct field and actual section and key name.

--- a/struct_test.go
+++ b/struct_test.go
@@ -47,17 +47,17 @@ type testStruct struct {
 }
 
 type testStructPassingFlags struct {
-	Name string `ini:"NAME" iniFlags:"mustExist"`
-	Age  int    `iniFlags:"strictParse"`
-	Male bool   `iniFlags:"mustExist;strictParse"`
+	Name string `ini:"NAME,mustExist"`
+	Age  int    `ini:",strict"`
+	Male bool   `ini:",mustExist,strict"`
 }
 
 type testStructFailingMustExistFlag struct {
-	Job string `iniFlags:"mustExist"`
+	Job string `ini:",mustExist"`
 }
 
 type testStructFailingStrictParseFlag struct {
-	Name int `ini:"NAME" iniFlags:"strictParse"`
+	Name int `ini:"NAME,strict"`
 }
 
 const _CONF_DATA_STRUCT = `


### PR DESCRIPTION
`ini` and `iniFlags` now all live in `ini`
Partially fixed bug in time.Time field parsing.  Fixing fully will take a broader refactor, as the buggy assumption is built in to the parser at a pretty low level.  The fundamental problem is that `reflect.TypeOf(time.Now()).Kind() == reflect.Struct` (and other complex types as well), and the parser assumes that you can accurately differentiate types for parsing based on Kind().
