### PR TITLE
get key string optimizations

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -130,6 +130,8 @@ type File struct {
 	looseMode bool
 
 	NameMapper
+
+	StaticKeys bool
 }
 
 // newFile initializes File object with given data sources.
@@ -140,6 +142,7 @@ func newFile(dataSources []dataSource, looseMode bool) *File {
 		sections:    make(map[string]*Section),
 		sectionList: make([]string, 0, 10),
 		looseMode:   looseMode,
+		StaticKeys:  false,
 	}
 }
 

--- a/key.go
+++ b/key.go
@@ -28,7 +28,7 @@ type Key struct {
 	name        string
 	value       string
 	isAutoIncr  bool
-	isStaticRef bool
+	isStaticVal bool
 }
 
 // Name returns name of key.
@@ -44,7 +44,7 @@ func (k *Key) Value() string {
 // String returns string representation of value.
 func (k *Key) String() string {
 	val := k.value
-	if !k.isStaticRef || strings.Index(val, "%") != -1 {
+	if k.isStaticVal || strings.Index(val, "%") == -1 {
 		return val
 	}
 

--- a/key.go
+++ b/key.go
@@ -23,11 +23,12 @@ import (
 
 // Key represents a key under a section.
 type Key struct {
-	s          *Section
-	Comment    string
-	name       string
-	value      string
-	isAutoIncr bool
+	s           *Section
+	Comment     string
+	name        string
+	value       string
+	isAutoIncr  bool
+	isStaticRef bool
 }
 
 // Name returns name of key.
@@ -43,7 +44,7 @@ func (k *Key) Value() string {
 // String returns string representation of value.
 func (k *Key) String() string {
 	val := k.value
-	if strings.Index(val, "%") == -1 {
+	if !k.isStaticRef || strings.Index(val, "%") != -1 {
 		return val
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -294,17 +294,16 @@ func (f *File) parse(reader io.Reader) (err error) {
 			p.count++
 		}
 
-		key, err := section.NewKey(kname, "")
-		if err != nil {
-			return err
-		}
-		key.isAutoIncr = isAutoIncr
-
 		value, err := p.readValue(line[offset:])
 		if err != nil {
 			return err
 		}
-		key.SetValue(value)
+
+		key, err := section.NewKey(kname, value)
+		if err != nil {
+			return err
+		}
+		key.isAutoIncr = isAutoIncr
 		key.Comment = strings.TrimSpace(p.comment.String())
 		p.comment.Reset()
 	}

--- a/section.go
+++ b/section.go
@@ -56,7 +56,8 @@ func (s *Section) NewKey(name, val string) (*Key, error) {
 	}
 
 	s.keyList = append(s.keyList, name)
-	s.keys[name] = &Key{s, "", name, val, false}
+	isStaticRef := s.f.StaticKeys && strings.Index(val, "%") != -1
+	s.keys[name] = &Key{s, "", name, val, false, isStaticRef}
 	s.keysHash[name] = val
 	return s.keys[name], nil
 }

--- a/section.go
+++ b/section.go
@@ -52,6 +52,7 @@ func (s *Section) NewKey(name, val string) (*Key, error) {
 
 	if inSlice(name, s.keyList) {
 		s.keys[name].value = val
+		s.keys[name].isStaticRef = s.f.StaticKeys && strings.Index(val, "%") != -1
 		return s.keys[name], nil
 	}
 

--- a/section.go
+++ b/section.go
@@ -52,13 +52,13 @@ func (s *Section) NewKey(name, val string) (*Key, error) {
 
 	if inSlice(name, s.keyList) {
 		s.keys[name].value = val
-		s.keys[name].isStaticRef = s.f.StaticKeys && strings.Index(val, "%") != -1
+		s.keys[name].isStaticVal = s.f.StaticKeys && strings.Index(val, "%") == -1
 		return s.keys[name], nil
 	}
 
 	s.keyList = append(s.keyList, name)
-	isStaticRef := s.f.StaticKeys && strings.Index(val, "%") != -1
-	s.keys[name] = &Key{s, "", name, val, false, isStaticRef}
+	isStaticVal := s.f.StaticKeys && strings.Index(val, "%") == -1
+	s.keys[name] = &Key{s, "", name, val, false, isStaticVal}
 	s.keysHash[name] = val
 	return s.keys[name], nil
 }


### PR DESCRIPTION
Added `StaticKeys` field to File object which causes recursive reference detection to happen at parse time on that File's keys instead of at value retrieval (call to `k.String()`) time, which speeds up getting strings for non-reference-value keys.
